### PR TITLE
Remove duplicate alias definition

### DIFF
--- a/zsh/alias.zsh
+++ b/zsh/alias.zsh
@@ -36,7 +36,6 @@ alias gre='git rebase'
 alias grea='git rebase --abort'
 alias grec='git rebase --continue'
 alias gred='git rebase develop'
-alias grei='git rebase -i'
 alias grem='git rebase master'
 
 # charset


### PR DESCRIPTION
## Summary
- fix duplication in git alias list

## Testing
- `python3 -m py_compile scripts/*.py`
- `zsh -n zsh/alias.zsh zsh/console.zsh zsh/plugin.zsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844119e0d048333abcd08b15ba91365