### PR TITLE
Fix typos, YAML, and add script tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Inspired by this repository.   
 [creasty/dotfiles](https://github.com/creasty/dotfiles)
 
-**For MaxOS, Apple Silicon only**.  
+**For macOS, Apple Silicon only**.
 First, get Xcode build tools.  
 Then follow below.
 

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -44,7 +44,7 @@ augroup texfile
 augroup END
 
 let g:slimv_lisp = 'ros run'
-let g:silmv_impl = 'sbcl'
+let g:slimv_impl = 'sbcl'
 nnoremap <silent> ,cl :VimShellInteractive ros -s swank -e '(swank:create-server :port 4005 :dont-close t)' wait<CR>
 
 "jedi-vim

--- a/provisioning/roles/asdf/tasks/main.yml
+++ b/provisioning/roles/asdf/tasks/main.yml
@@ -1,6 +1,5 @@
-asdf: {}
-  - name: fetch asdf repo
-    git:
-      repo: https://github.com/asdf-vm/asdf.git --branch v0.11.1
-      dest: '{{ asdf.dir }}'
-      when: asdf.dir
+- name: fetch asdf repo
+  git:
+    repo: https://github.com/asdf-vm/asdf.git --branch v0.11.1
+    dest: '{{ asdf.dir }}'
+  when: asdf.dir

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,18 @@
+import subprocess
+import sys
+import os
+import unittest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), '..', 'scripts')
+
+class TestScripts(unittest.TestCase):
+    def test_upper(self):
+        output = subprocess.check_output([sys.executable, os.path.join(SCRIPTS_DIR, 'upper.py'), 'hello'])
+        self.assertEqual(output.decode().strip(), 'HELLO')
+
+    def test_lower(self):
+        output = subprocess.check_output([sys.executable, os.path.join(SCRIPTS_DIR, 'lower.py'), 'HELLO'])
+        self.assertEqual(output.decode().strip(), 'hello')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -50,7 +50,7 @@ augroup texfile
 augroup END
 
 let g:slimv_lisp = 'ros run'
-let g:silmv_impl = 'sbcl'
+let g:slimv_impl = 'sbcl'
 nnoremap <silent> ,cl :VimShellInteractive ros -s swank -e '(swank:create-server :port 4005 :dont-close t)' wait<CR>
 
 syntax enable


### PR DESCRIPTION
## Summary
- correct `slimv_impl` variable names in vim configs
- fix README typo
- clean up asdf Ansible task syntax
- add unittests for `scripts/upper.py` and `scripts/lower.py`

## Testing
- `python3 -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_6844146b09508333a6ae1228f164bec1