### PR TITLE
Fix dry-run test for up script on master

### DIFF
--- a/tests/test_up_script.py
+++ b/tests/test_up_script.py
@@ -16,7 +16,15 @@ class TestUpScript(unittest.TestCase):
             check=True,
         )
         output = result.stdout
-        self.assertIn('skip (working on a non-master branch)', output)
+        branch = subprocess.check_output(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            cwd=env['DOTFILES_PATH'],
+            text=True,
+        ).strip()
+        if branch != 'master':
+            self.assertIn('skip (working on a non-master branch)', output)
+        else:
+            self.assertNotIn('skip (working on a non-master branch)', output)
         self.assertIn('skip (xcrun not found)', output)
         self.assertIn('Provisioning...', output)
         self.assertTrue(


### PR DESCRIPTION
## Summary
- handle `up` dry run test when running on master branch by checking the current branch

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68445f0c1a008333a02ff30d7ec99857