### PR TITLE
Replace anyenv with asdf for version management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Architecture Overview
+
+This is a macOS-focused dotfiles repository using Ansible for automated provisioning. The main setup process:
+
+1. `up` script - Entry point that handles repository cloning/updating, Xcode license, and environment setup
+2. Ansible playbook system in `provisioning/` - Handles application installation and configuration linking
+3. Shell configuration in `bash/`, `zsh/`, and `shell/` - Environment variables and shell customization
+4. Application configs in dedicated directories - Vim/Neovim, Karabiner, tmux, git, etc.
+
+## Key Commands
+
+**Setup/Installation:**
+```bash
+./up                    # Full dotfiles setup and provisioning
+```
+
+**Provisioning:**
+```bash
+./provisioning/run.sh   # Run Ansible playbook directly
+ansible-playbook -i 'localhost,' --extra-vars='@config.yml' playbook.yml
+```
+
+**Development:**
+The repository uses Ansible roles in `provisioning/roles/`:
+- `homebrew` - Package and application installation
+- `link` - Symlink creation for config files  
+- `vim` - Vim/Neovim setup
+- `asdf` - Version manager setup
+
+## Configuration Structure
+
+- `provisioning/config.yml` - Central configuration for homebrew packages, applications, and symlink mappings
+- `provisioning/playbook.yml` - Ansible playbook defining role execution order
+- Config files are organized by application (git/, vim/, karabiner/, etc.)
+- Shell configs use modular approach with separate files for different purposes
+
+## Environment Setup
+
+The setup assumes:
+- macOS with Apple Silicon
+- Xcode command line tools installed
+- Git available for repository cloning
+- Target audience: developers needing comprehensive dev environment
+
+Key environment variables are set in `shell/env.sh` including Homebrew paths, GOPATH, and development tool paths.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,4 @@ Then follow below.
   - karabiner settings
   - tmux
   - install apps and packages by homebrew
-
-TODO: use asdf
+  - asdf for version management (Node.js, Python, Ruby, etc.)

--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -1,2 +1,6 @@
 [ -f ~/.bashrc ] && source ~/.bashrc
-eval "$(anyenv init -)"
+
+# Load dotfiles environment
+if [ -f "$HOME/dotfiles/shell/env.sh" ]; then
+  source "$HOME/dotfiles/shell/env.sh"
+fi

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -2,6 +2,9 @@ source ~/common.bash
 source ~/local.bash
 
 # Load dotfiles environment (includes asdf and homebrew setup)
-if [ -f "$HOME/dotfiles/shell/env.sh" ]; then
-  source "$HOME/dotfiles/shell/env.sh"
+# Ensure DOTFILES_PATH is defined, defaulting to $HOME/dotfiles
+DOTFILES_PATH=${DOTFILES_PATH:-"$HOME/dotfiles"}
+
+if [ -f "$DOTFILES_PATH/shell/env.sh" ]; then
+  source "$DOTFILES_PATH/shell/env.sh"
 fi

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -1,10 +1,7 @@
 source ~/common.bash
 source ~/local.bash
 
-export ANYENV_DIR=$HOME/.anyenv
-export PATH=/opt/homebrew/bin:$PATH
-export PATH=$ANYENV_DIR/bin:$PATH
-
-if [ -d $HOME/.anyenv ] && command 'anyenv' > /dev/null 2>&1; then
-  eval "$(anyenv install --init)"
+# Load dotfiles environment (includes asdf and homebrew setup)
+if [ -f "$HOME/dotfiles/shell/env.sh" ]; then
+  source "$HOME/dotfiles/shell/env.sh"
 fi

--- a/provisioning/config.yml
+++ b/provisioning/config.yml
@@ -1,5 +1,18 @@
 asdf:
-  dir:  '{{ home_path }}/.asdf}}'
+  dir: '{{ home_path }}/.asdf'
+  plugins:
+    - nodejs
+    - python
+    - ruby
+    - java
+    - golang
+  versions:
+    - name: nodejs
+      version: latest
+    - name: python
+      version: latest
+    - name: ruby
+      version: latest
 
 homebrew: 
   applications:

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -18,4 +18,6 @@
     #-----------------------------------------------
     - role: homebrew
       tags: ['install', 'homebrew']
+    - role: asdf
+      tags: ['install', 'asdf']
 

--- a/provisioning/roles/asdf/tasks/main.yml
+++ b/provisioning/roles/asdf/tasks/main.yml
@@ -1,6 +1,21 @@
-asdf: {}
-  - name: fetch asdf repo
-    git:
-      repo: https://github.com/asdf-vm/asdf.git --branch v0.11.1
-      dest: '{{ asdf.dir }}'
-      when: asdf.dir
+- name: fetch asdf repo
+  git:
+    repo: https://github.com/asdf-vm/asdf.git
+    version: v0.14.1
+    dest: '{{ asdf.dir }}'
+  when: asdf.dir is defined
+
+- name: install asdf plugins
+  shell: |
+    source {{ asdf.dir }}/asdf.sh
+    asdf plugin add {{ item }} || true
+  loop: '{{ asdf.plugins }}'
+  when: asdf.plugins is defined
+
+- name: install asdf versions
+  shell: |
+    source {{ asdf.dir }}/asdf.sh
+    asdf install {{ item.name }} {{ item.version }}
+    asdf global {{ item.name }} {{ item.version }}
+  loop: '{{ asdf.versions }}'
+  when: asdf.versions is defined

--- a/shell/env.sh
+++ b/shell/env.sh
@@ -1,10 +1,28 @@
 export HOMEBREW_PREFIX="/opt/homebrew";
 export HOMEBREW_CELLAR="/opt/homebrew/Cellar";
 export HOMEBREW_REPOSITORY="/opt/homebrew";
-export GOPATH=$(go env GOPATH)
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin${PATH+:$PATH}";
 export PATH="$PATH:$HOME/Library/Application Support/JetBrains/Toolbox/scripts"
-export PATH="$PATH:$GOPATH/bin"
 export MANPATH="/opt/homebrew/share/man${MANPATH+:$MANPATH}:";
 export INFOPATH="/opt/homebrew/share/info:${INFOPATH:-}";
 export LSCOLORS=cxfxcxdxbxegedabagacad
+
+# asdf
+export ASDF_DIR="$HOME/.asdf"
+if [ -f "$ASDF_DIR/asdf.sh" ]; then
+  source "$ASDF_DIR/asdf.sh"
+fi
+
+# direnv (works well with asdf)
+if command -v direnv >/dev/null 2>&1; then
+  # Detect current shell and use appropriate hook
+  if [ -n "$ZSH_VERSION" ]; then
+    eval "$(direnv hook zsh)"
+  elif [ -n "$BASH_VERSION" ]; then
+    eval "$(direnv hook bash)"
+  fi
+fi
+
+export GOPATH=$(go env GOPATH 2>/dev/null || echo "$HOME/go")
+export PATH="$PATH:$GOPATH/bin"
+

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,12 +1,12 @@
 source "$DOTFILES_PATH/zsh/plugin.zsh"
 source "$DOTFILES_PATH/zsh/alias.zsh"
 source "$DOTFILES_PATH/zsh/console.zsh"
-. "$HOME/.asdf/asdf.sh"
 
-# setup direnv
-eval "$(direnv hook zsh)"
-# append completions to fpath
-fpath=(${ASDF_DIR}/completions $fpath)
+# asdf completions (ASDF_DIR is set in shell/env.sh)
+if [ -n "${ASDF_DIR:-}" ]; then
+  fpath=(${ASDF_DIR}/completions $fpath)
+fi
+
 # initialise completions with ZSH's compinit
 autoload -Uz compinit && compinit
 


### PR DESCRIPTION
## Summary
• Replace anyenv with asdf for language version management
• Implement comprehensive asdf provisioning via Ansible
• Centralize shell configuration for consistent environment setup
• Add support for Node.js, Python, Ruby, Java, and Go via asdf plugins

## Changes Made
### Provisioning (b544470)
- Fixed asdf Ansible role with proper plugin and version installation
- Added common language plugins configuration
- Integrated asdf role into main playbook execution

### Shell Environment (18ad5fb)  
- Added asdf sourcing with ASDF_DIR export for completions
- Implemented shell-aware direnv hooks (zsh/bash detection)
- Centralized version manager configuration in shell/env.sh

### Configuration Migration (1883d26)
- Removed anyenv initialization from bash configs
- Updated zsh config to use centralized shell environment
- Ensured consistent environment across all shells

### Documentation (8768f70)
- Updated README to reflect asdf implementation
- Added CLAUDE.md for development guidance
- Documented new asdf-based setup

## Test Plan
- [ ] Run `./up` to verify asdf installation via Ansible
- [ ] Test shell loading in both bash and zsh environments
- [ ] Verify asdf commands are available and working
- [ ] Check direnv integration functions correctly
- [ ] Confirm language plugins install and set versions properly

🤖 Generated with [Claude Code](https://claude.ai/code)