### PR TITLE
Fix unbound variable error in shell environment setup

### DIFF
--- a/shell/env.sh
+++ b/shell/env.sh
@@ -16,9 +16,9 @@ fi
 # direnv (works well with asdf)
 if command -v direnv >/dev/null 2>&1; then
   # Detect current shell and use appropriate hook
-  if [ -n "$ZSH_VERSION" ]; then
+  if [ -n "${ZSH_VERSION:-}" ]; then
     eval "$(direnv hook zsh)"
-  elif [ -n "$BASH_VERSION" ]; then
+  elif [ -n "${BASH_VERSION:-}" ]; then
     eval "$(direnv hook bash)"
   fi
 fi


### PR DESCRIPTION
## Summary
- Fixed unbound variable error in `shell/env.sh` that was preventing the dotfiles setup from completing successfully
- Changed variable checks to use parameter expansion with default empty values (`${VAR:-}`)

## Test plan
- [x] Ran `sh up` command successfully without errors
- [x] Environment variable detection works correctly for both Zsh and Bash
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)