### PR TITLE
Fix Ansible provisioning warnings and deprecated packages

### DIFF
--- a/config/.ansible.cfg
+++ b/config/.ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 retry_files_enabled = True
 retry_files_save_path = ~/.ansible
+interpreter_python = auto_silent

--- a/provisioning/config.yml
+++ b/provisioning/config.yml
@@ -16,8 +16,6 @@ asdf:
 
 homebrew: 
   applications:
-    - adoptopenjdk8
-    - adoptopenjdk15
     - alfred
     - android-studio
     - appcleaner
@@ -33,7 +31,6 @@ homebrew:
     - jetbrains-toolbox
     - kap
     - karabiner-elements
-    - kindle
     - kitematic
     - macs-fan-control
     - miro

--- a/provisioning/roles/link/tasks/main.yml
+++ b/provisioning/roles/link/tasks/main.yml
@@ -31,10 +31,11 @@
 
 - name: create symlinks
   file:
-    src:   '{{ dotfiles_path }}/{{ item.key }}'
-    dest:  '{{ home_path }}/{{ item.value }}'
-    state: link
-    force: yes
+    src:    '{{ dotfiles_path }}/{{ item.key }}'
+    dest:   '{{ home_path }}/{{ item.value }}'
+    state:  link
+    force:  yes
+    follow: false
   loop_control:
     label: '{{ item.value }}'
   with_dict: '{{ link }}'


### PR DESCRIPTION
## Summary
- Fixed Ansible Python interpreter warning by adding `interpreter_python = auto_silent` to `.ansible.cfg`
- Fixed symlink fs attributes warning by adding `follow: false` to link task
- Removed deprecated Java casks: `adoptopenjdk8` and `adoptopenjdk15` (using deprecated appcast method)
- Removed discontinued `kindle` cask (disabled upstream as of 2024-12-16)

## Test plan
- [x] Ran `sh up` successfully without warnings
- [x] All symlinks created properly with `follow: false` 
- [x] Homebrew cask installation completed without deprecated package errors
- [x] No breaking changes to existing functionality

## Before/After
**Before**: Setup script failed with multiple warnings and errors
**After**: Setup script runs cleanly with only minor kitematic upgrade notice

🤖 Generated with [Claude Code](https://claude.ai/code)