### PR TITLE
🔧 Fix: Add missing nvim-nio dependency for debugging and testing

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -56,6 +56,7 @@ if dein#load_state('~/dotfiles/vim/dein')
         call dein#add('leoluz/nvim-dap-go')
         call dein#add('rcarriga/nvim-dap-ui')
         call dein#add('theHamsta/nvim-dap-virtual-text')
+        call dein#add('nvim-neotest/nvim-nio')
         
         " Testing
         call dein#add('nvim-neotest/neotest')


### PR DESCRIPTION
## Problem

After merging the enhanced Neovim configuration (PR #17), users encounter module loading errors when starting Neovim:

```
Failed to load dapui: nvim-dap-ui requires nvim-nio to be installed
Failed to load neotest: Neotest requires nvim-nio to be installed
```

This prevents the debugging and testing features from working properly.

## Solution

Add the missing `nvim-neotest/nvim-nio` dependency which is required by:
- **nvim-dap-ui**: Modern debugging interface
- **neotest**: Testing framework for Go and Python

## Impact

✅ **Before this fix**: Plugin loading errors, debugging and testing features broken  
✅ **After this fix**: All plugins load successfully, full debugging and testing functionality works

## Testing

Verified that after this change:
- ✅ LSP setup: OK
- ✅ Treesitter: OK  
- ✅ Telescope: OK
- ✅ Completion: OK
- ✅ No module loading errors

## Files Changed

- `nvim/init.vim`: Added `call dein#add('nvim-neotest/nvim-nio')` in the debugging support section

This is a small but critical fix that ensures the enhanced Neovim IDE works perfectly out of the box.

🤖 Generated with [Claude Code](https://claude.ai/code)