### PR TITLE
Add curl one-line bootstrap installing Homebrew, git, then setup

### DIFF
--- a/.bin/install.sh
+++ b/.bin/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# One-line bootstrap for a fresh macOS machine:
+#
+#   curl -fsSL https://raw.githubusercontent.com/hiramekun/dotfiles/main/.bin/install.sh | bash
+#
+# Homebrew is installed first because its installer also installs the Xcode
+# Command Line Tools (and therefore git), which are then used to clone this
+# repository and hand off to `up` for the full setup.
+
+REPO_URL="${DOTFILES_REPO_URL:-https://github.com/hiramekun/dotfiles.git}"
+DOTFILES_PATH="${DOTFILES_PATH:-$HOME/dotfiles}"
+
+require_apple_silicon_macos() {
+  if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+    printf 'This setup supports macOS on Apple Silicon only.\n' >&2
+    exit 1
+  fi
+}
+
+install_homebrew() {
+  if ! command -v brew >/dev/null 2>&1; then
+    printf 'Installing Homebrew (this also installs the Xcode Command Line Tools and git)...\n'
+    # The Homebrew installer installs the Command Line Tools when missing, which
+    # provides git for the clone below. NONINTERACTIVE skips its confirmation
+    # prompt so the `curl | bash` bootstrap does not stall on stdin.
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  fi
+
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+}
+
+clone_or_update_repo() {
+  if [ -d "$DOTFILES_PATH/.git" ]; then
+    printf 'Updating existing dotfiles at %s...\n' "$DOTFILES_PATH"
+    git -C "$DOTFILES_PATH" pull --ff-only \
+      || printf 'Could not fast-forward; using the existing checkout.\n' >&2
+  else
+    printf 'Cloning dotfiles into %s...\n' "$DOTFILES_PATH"
+    git clone "$REPO_URL" "$DOTFILES_PATH"
+  fi
+}
+
+main() {
+  require_apple_silicon_macos
+  install_homebrew
+  clone_or_update_repo
+  exec "$DOTFILES_PATH/up"
+}
+
+main "$@"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ On a fresh machine, one command provisions everything. It installs Homebrew
 this repository into `~/dotfiles` with that git, and runs the complete setup:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/hiramekun/dotfiles/main/.bin/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/hiramekun/dotfiles/main/install.sh | bash
 ```
 
 If the repository is already cloned, run the bootstrap directly:
@@ -112,6 +112,7 @@ To install newly added plugins manually, run this inside Neovim:
 .
 ├── Brewfile           # Homebrew dependencies
 ├── mise.toml          # Runtimes, tools, dotfiles, macOS defaults, and tasks
+├── install.sh         # curl one-line bootstrap for a fresh machine
 ├── up                 # Bootstrap entry point
 ├── scripts/           # Provisioning and utility scripts
 ├── nvim/ and vim/     # Neovim and Vim configuration

--- a/README.md
+++ b/README.md
@@ -13,21 +13,23 @@ Inspired by [creasty/dotfiles](https://github.com/creasty/dotfiles).
 
 ## Setup
 
-Install the Xcode Command Line Tools first:
+On a fresh machine, one command provisions everything. It installs Homebrew
+(whose installer also installs the Xcode Command Line Tools and git), clones
+this repository into `~/dotfiles` with that git, and runs the complete setup:
 
 ```sh
-xcode-select --install
+curl -fsSL https://raw.githubusercontent.com/hiramekun/dotfiles/main/.bin/install.sh | bash
 ```
 
-Then clone and provision the environment:
+If the repository is already cloned, run the bootstrap directly:
 
 ```sh
-git clone https://github.com/hiramekun/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 ./up
 ```
 
-`up` installs Homebrew and mise when needed, then runs the complete setup.
+`up` installs Homebrew (with the Command Line Tools and git) and mise when
+needed, then runs the complete setup.
 
 ## Commands
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # One-line bootstrap for a fresh macOS machine:
 #
-#   curl -fsSL https://raw.githubusercontent.com/hiramekun/dotfiles/main/.bin/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/hiramekun/dotfiles/main/install.sh | bash
 #
 # Homebrew is installed first because its installer also installs the Xcode
 # Command Line Tools (and therefore git), which are then used to clone this

--- a/tests/test_mise_setup.sh
+++ b/tests/test_mise_setup.sh
@@ -55,6 +55,7 @@ if find "$REPO_ROOT/provisioning" -type f -print -quit 2>/dev/null | grep -q .; 
 fi
 
 bash -n "$REPO_ROOT/up"
+bash -n "$REPO_ROOT/.bin/install.sh"
 bash -n "$REPO_ROOT/scripts/setup-vim"
 grep -q 'dein#check_install()' "$REPO_ROOT/scripts/setup-vim"
 if grep -q 'max_line_len' "$REPO_ROOT/nvim/init.vim"; then

--- a/tests/test_mise_setup.sh
+++ b/tests/test_mise_setup.sh
@@ -55,7 +55,7 @@ if find "$REPO_ROOT/provisioning" -type f -print -quit 2>/dev/null | grep -q .; 
 fi
 
 bash -n "$REPO_ROOT/up"
-bash -n "$REPO_ROOT/.bin/install.sh"
+bash -n "$REPO_ROOT/install.sh"
 bash -n "$REPO_ROOT/scripts/setup-vim"
 grep -q 'dein#check_install()' "$REPO_ROOT/scripts/setup-vim"
 if grep -q 'max_line_len' "$REPO_ROOT/nvim/init.vim"; then

--- a/up
+++ b/up
@@ -32,18 +32,27 @@ BANNER
   printf '\033[0m\n'
 }
 
-check_platform() {
-  local xcode_check
-
+require_apple_silicon_macos() {
   if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
     printf 'This setup supports macOS on Apple Silicon only.\n' >&2
     exit 1
   fi
+}
 
-  if ! xcode-select -p >/dev/null 2>&1; then
-    printf 'Install Xcode Command Line Tools with `xcode-select --install`, then rerun this script.\n' >&2
-    exit 1
+install_homebrew() {
+  if ! command -v brew >/dev/null 2>&1; then
+    printf 'Installing Homebrew (this also installs the Xcode Command Line Tools and git)...\n'
+    # The Homebrew installer installs the Command Line Tools when missing, which
+    # provides git for the rest of the setup. NONINTERACTIVE skips its
+    # confirmation prompt so the `curl | bash` bootstrap does not stall on stdin.
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
+
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+}
+
+accept_xcode_license() {
+  local xcode_check
 
   xcode_check="$(/usr/bin/xcrun clang 2>&1 || true)"
   case "$xcode_check" in
@@ -52,15 +61,6 @@ check_platform() {
       sudo xcodebuild -license accept
       ;;
   esac
-}
-
-install_homebrew() {
-  if ! command -v brew >/dev/null 2>&1; then
-    printf 'Installing Homebrew...\n'
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  fi
-
-  eval "$(/opt/homebrew/bin/brew shellenv)"
 }
 
 install_mise() {
@@ -85,8 +85,9 @@ run_mise_task() {
 
 main() {
   print_header
-  check_platform
+  require_apple_silicon_macos
   install_homebrew
+  accept_xcode_license
   install_mise
   run_mise_task "$@"
 }


### PR DESCRIPTION
## 概要

初回セットアップを curl 一発で完結できるようにします。

```sh
curl -fsSL https://raw.githubusercontent.com/hiramekun/dotfiles/main/install.sh | bash
```

## フロー

Homebrew を先に入れることで、その公式インストーラーが Xcode Command Line Tools（＝git 同梱）もヘッドレスで導入します。得られた git でリポジトリを clone し、`up` に処理を引き継ぎます。

1. macOS / Apple Silicon チェック
2. Homebrew をインストール（CLT と git も入る、`NONINTERACTIVE=1` で確認プロンプト回避）
3. その git で `~/dotfiles` へ clone（既存なら best-effort で `pull --ff-only`）
4. `up` を `exec` してフルセットアップ

## 変更点

- **新規 `install.sh`**: curl のターゲット。Homebrew → clone → `up` の橋渡し
- **`up` の再構成**:
  - GUI ダイアログ待機の Command Line Tools インストールを削除し、Homebrew に CLT/git を任せる
  - Homebrew インストールを `NONINTERACTIVE=1` で実行（`curl | bash` で stdin 待ちにより止まるのを防止）
  - Xcode ライセンス確認を Homebrew インストール後（＝CLT 導入後）に移動
- **README**: セットアップ手順を curl 一行に更新
- **tests**: `bash -n install.sh` の構文チェックを追加

## 補足

- git は CLT 同梱の `/usr/bin/git`（常に PATH 上）を使用
- `install_homebrew` は install.sh と `up` に重複するが、install.sh は clone 前に単独実行される必要があるため共有不可（curl フローでは `up` 側は no-op）

## 動作確認

- `bash -n install.sh` / `bash -n up` 通過
- **実機の `curl | bash` フル実行は未検証**（このマシンは既に Homebrew/CLT/git 導入済みで初回フローを再現できないため）。ロジックレビューと構文確認までが担保範囲

🤖 Generated with [Claude Code](https://claude.com/claude-code)